### PR TITLE
[FeatureFlag] Propose a simple version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "symfony/error-handler": "self.version",
         "symfony/event-dispatcher": "self.version",
         "symfony/expression-language": "self.version",
+        "symfony/feature-flag": "self.version",
         "symfony/filesystem": "self.version",
         "symfony/finder": "self.version",
         "symfony/form": "self.version",

--- a/src/Symfony/Bridge/Twig/Extension/FeatureFlagExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FeatureFlagExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class FeatureFlagExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('is_feature_enabled', [FeatureFlagRuntime::class, 'isFeatureEnabled']),
+            new TwigFunction('get_feature_value', [FeatureFlagRuntime::class, 'getFeatureValue']),
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Twig/Extension/FeatureFlagRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/FeatureFlagRuntime.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\FeatureFlag\FeatureCheckerInterface;
+
+final class FeatureFlagRuntime
+{
+    public function __construct(private readonly ?FeatureCheckerInterface $featureEnabledChecker = null)
+    {
+    }
+
+    public function isFeatureEnabled(string $featureName, mixed $expectedValue = true): bool
+    {
+        if (null === $this->featureEnabledChecker) {
+            throw new \LogicException(sprintf('An instance of "%s" must be provided to use "%s()".', FeatureCheckerInterface::class, __METHOD__));
+        }
+
+        return $this->featureEnabledChecker->isEnabled($featureName, $expectedValue);
+    }
+
+    public function getFeatureValue(string $featureName): mixed
+    {
+        if (null === $this->featureEnabledChecker) {
+            throw new \LogicException(sprintf('An instance of "%s" must be provided to use "%s()".', FeatureCheckerInterface::class, __METHOD__));
+        }
+
+        return $this->featureEnabledChecker->getValue($featureName);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FeatureFlagPass.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\FeatureFlag\Debug\TraceableFeatureChecker;
+
+class FeatureFlagPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('feature_flag.feature_checker')) {
+            return;
+        }
+
+        $features = [];
+        foreach ($container->findTaggedServiceIds('feature_flag.feature') as $serviceId => $tags) {
+            $className = $this->getServiceClass($container, $serviceId);
+            $r = $container->getReflectionClass($className);
+
+            if (null === $r) {
+                throw new \RuntimeException(sprintf('Invalid service "%s": class "%s" does not exist.', $serviceId, $className));
+            }
+
+            foreach ($tags as $tag) {
+                $featureName = ($tag['feature'] ?? '') ?: $className;
+                if (array_key_exists($featureName, $features)) {
+                    throw new \RuntimeException(sprintf('Feature "%s" already defined.', $featureName));
+                }
+
+                $method = $tag['method'] ?? '__invoke';
+                if (!$r->hasMethod($method)) {
+                    throw new \RuntimeException(sprintf('Invalid feature strategy "%s": method "%s::%s()" does not exist.', $serviceId, $r->getName(), $method));
+                }
+
+                $features[$featureName] = $container->setDefinition(
+                    ".feature_flag.feature",
+                    (new Definition(\Closure::class))
+                        ->setLazy(true)
+                        ->setFactory([\Closure::class, 'fromCallable'])
+                        ->setArguments([[new Reference($serviceId), $method]]),
+                );
+            }
+        }
+
+        $container->getDefinition('feature_flag.feature_registry')
+            ->setArgument('$features', $features)
+        ;
+
+        if (!$container->has('feature_flag.data_collector')) {
+            return;
+        }
+
+        foreach ($container->findTaggedServiceIds('feature_flag.feature_checker') as $serviceId => $tags) {
+            $container->register('debug.'.$serviceId, TraceableFeatureChecker::class)
+                ->setDecoratedService($serviceId)
+                ->setArguments([
+                    '$decorated' => new Reference('.inner'),
+                    '$dataCollector' => new Reference('feature_flag.data_collector'),
+                ])
+            ;
+        }
+    }
+    private function getServiceClass(ContainerBuilder $container, string $serviceId): string|null
+    {
+        while (true) {
+            $definition = $container->findDefinition($serviceId);
+
+            if (!$definition->getClass() && $definition instanceof ChildDefinition) {
+                $serviceId = $definition->getParent();
+
+                continue;
+            }
+
+            return $definition->getClass();
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -48,6 +48,8 @@ class UnusedTagsPass implements CompilerPassInterface
         'controller.targeted_value_resolver',
         'data_collector',
         'event_dispatcher.dispatcher',
+        'feature_flag.feature',
+        'feature_flag.feature_checker',
         'form.type',
         'form.type_extension',
         'form.type_guesser',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\FeatureFlag\FeatureCheckerInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpClient\HttpClient;
@@ -177,6 +178,7 @@ class Configuration implements ConfigurationInterface
         $this->addHtmlSanitizerSection($rootNode, $enableIfStandalone);
         $this->addWebhookSection($rootNode, $enableIfStandalone);
         $this->addRemoteEventSection($rootNode, $enableIfStandalone);
+        $this->addFeatureFlagSection($rootNode, $enableIfStandalone);
 
         return $treeBuilder;
     }
@@ -2448,5 +2450,17 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function addFeatureFlagSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('feature_flag')
+                    ->info('FeatureFlag configuration')
+                    ->{$enableIfStandalone('symfony/feature-flag', FeatureCheckerInterface::class)}()
+                    ->fixXmlConfig('feature_flag')
+                ->end()
+            ->end();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -70,6 +70,9 @@ use Symfony\Component\Dotenv\Command\DebugCommand;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\FeatureFlag\Attribute\AsFeature;
+use Symfony\Component\FeatureFlag\FeatureChecker;
+use Symfony\Component\FeatureFlag\FeatureRegistryInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
 use Symfony\Component\Form\Extension\HtmlSanitizer\Type\TextTypeHtmlSanitizerExtension;
@@ -139,6 +142,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
 use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Routing\Router;
 use Symfony\Component\Scheduler\Attribute\AsCronTask;
 use Symfony\Component\Scheduler\Attribute\AsPeriodicTask;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -261,6 +265,7 @@ class FrameworkExtension extends Extension
         $this->readConfigEnabled('property_access', $container, $config['property_access']);
         $this->readConfigEnabled('profiler', $container, $config['profiler']);
         $this->readConfigEnabled('workflows', $container, $config['workflows']);
+        $this->readConfigEnabled('feature_flag', $container, $config['feature_flag']);
 
         // A translator must always be registered (as support is included by
         // default in the Form and Validator component). If disabled, an identity
@@ -563,6 +568,13 @@ class FrameworkExtension extends Extension
             }
 
             $this->registerHtmlSanitizerConfiguration($config['html_sanitizer'], $container, $loader);
+        }
+
+        if ($this->readConfigEnabled('feature_flag', $container, $config['feature_flag'])) {
+            if (!class_exists(FeatureChecker::class)) {
+                throw new LogicException('FeatureFlag support cannot be enabled as the FeatureFlag component is not installed. Try running "composer require symfony/feature-flag".');
+            }
+            $this->registerFeatureFlagConfiguration($config['feature_flag'], $container, $loader);
         }
 
         if (ContainerBuilder::willBeAvailable('symfony/mime', MimeTypes::class, ['symfony/framework-bundle'])) {
@@ -874,6 +886,10 @@ class FrameworkExtension extends Extension
 
         if ($this->isInitializedConfigEnabled('serializer') && $config['collect_serializer_data']) {
             $loader->load('serializer_debug.php');
+        }
+
+        if ($this->isInitializedConfigEnabled('feature_flag')) {
+            $loader->load('feature_flag_debug.php');
         }
 
         $container->setParameter('profiler_listener.only_exceptions', $config['only_exceptions']);
@@ -2972,6 +2988,45 @@ class FrameworkExtension extends Extension
             if ('default' !== $sanitizerName) {
                 $container->registerAliasForArgument($sanitizerId, HtmlSanitizerInterface::class, $sanitizerName);
             }
+        }
+    }
+
+    private function registerFeatureFlagConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
+    {
+        $loader->load('feature_flag.php');
+
+        $container->registerForAutoconfiguration(FeatureRegistryInterface::class)
+            ->addTag('feature_flag.feature_registry')
+        ;
+
+        $container->registerAttributeForAutoconfiguration(AsFeature::class,
+            static function (ChildDefinition $definition, AsFeature $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+                $featureName = $attribute->name;
+
+                if ($reflector instanceof \ReflectionClass) {
+                    $className = $reflector->getName();
+                    $method = $attribute->method;
+
+                    $featureName ??= $className;
+                } else {
+                    $className = $reflector->getDeclaringClass()->getName();
+                    if (null !== $attribute->method && $reflector->getName() !== $attribute->method) {
+                        throw new \LogicException(sprintf('Using the #[%s(method: %s)] attribute on a method is not valid. Either remove the method value or move this to the top of the class (%s)', AsFeature::class, $attribute->method, $className));
+                    }
+
+                    $method = $reflector->getName();
+                    $featureName ??= "{$className}::{$method}";
+                }
+
+                $definition->addTag('feature_flag.feature', [
+                    'feature' => $featureName,
+                    'method' => $method,
+                ]);
+            },
+        );
+
+        if (ContainerBuilder::willBeAvailable('symfony/routing', Router::class, ['symfony/framework-bundle', 'symfony/routing'])) {
+            $loader->load('feature_flag_routing.php');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProce
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FeatureFlagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
@@ -173,6 +174,7 @@ class FrameworkBundle extends Bundle
         // must be registered after MonologBundle's LoggerChannelPass
         $container->addCompilerPass(new ErrorLoggerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new VirtualRequestStackPass());
+        $container->addCompilerPass(new FeatureFlagPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\FeatureFlag\FeatureChecker;
+use Symfony\Component\FeatureFlag\FeatureCheckerInterface;
+use Symfony\Component\FeatureFlag\FeatureRegistry;
+use Symfony\Component\FeatureFlag\FeatureRegistryInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('feature_flag.feature_registry', FeatureRegistry::class)
+            ->args([
+                '$features' => abstract_arg('Defined in FeatureFlagPass.'),
+            ])
+            ->alias(FeatureRegistryInterface::class, 'feature_flag.feature_registry')
+
+        ->set('feature_flag.feature_checker', FeatureChecker::class)
+            ->args([
+                '$featureRegistry' => service('feature_flag.feature_registry'),
+                '$default' => false,
+            ])
+            ->alias(FeatureCheckerInterface::class, 'feature_flag.feature_checker')
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag_debug.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\FeatureFlag\DataCollector\FeatureCheckerDataCollector;
+use Symfony\Component\FeatureFlag\Debug\TraceableFeatureChecker;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('feature_flag.data_collector', FeatureCheckerDataCollector::class)
+            ->args([
+                '$featureRegistry' => service('feature_flag.feature_registry'),
+            ])
+            ->tag('data_collector', ['template' => '@WebProfiler/Collector/feature_flag.html.twig', 'id' => 'feature_flag'])
+
+
+        ->set('debug.feature_flag.feature_checker', TraceableFeatureChecker::class)
+            ->decorate('feature_flag.feature_checker')
+            ->args([
+                '$decorated' => service('debug.feature_flag.feature_checker.inner'),
+                '$dataCollector' => service('feature_flag.data_collector'),
+            ])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/feature_flag_routing.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('feature_flag.routing_expression_language_function.is_enabled', \Closure::class)
+            ->factory([\Closure::class, 'fromCallable'])
+            ->args([
+                [service('feature_flag.feature_checker'), 'isEnabled'],
+            ])
+            ->tag('routing.expression_language_function', ['function' => 'is_feature_enabled'])
+
+
+        ->set('feature_flag.routing_expression_language_function.get_value', \Closure::class)
+            ->factory([\Closure::class, 'fromCallable'])
+            ->args([
+                [service('feature_flag.feature_checker'), 'getValue'],
+            ])
+            ->tag('routing.expression_language_function', ['function' => 'get_feature_value'])
+
+        ->get('feature_flag.feature_checker')
+            ->tag('routing.condition_service', ['alias' => 'feature'])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -785,6 +785,9 @@ class ConfigurationTest extends TestCase
             'remote-event' => [
                 'enabled' => false,
             ],
+            'feature_flag' => [
+                'enabled' => false,
+            ],
         ];
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\FeatureFlag\FeatureChecker;
 use Symfony\Component\Form\AbstractRendererEngine;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -91,6 +92,10 @@ class TwigExtension extends Extension
 
         if ($container::willBeAvailable('symfony/asset-mapper', AssetMapper::class, ['symfony/twig-bundle'])) {
             $loader->load('importmap.php');
+        }
+
+        if ($container::willBeAvailable('symfony/feature-flag', FeatureChecker::class, ['symfony/twig-bundle'])) {
+            $loader->load('feature_flag.php');
         }
 
         $container->setParameter('twig.form.resources', $config['form_themes']);

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/feature_flag.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/feature_flag.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bridge\Twig\Extension\FeatureFlagExtension;
+use Symfony\Bridge\Twig\Extension\FeatureFlagRuntime;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('twig.runtime.feature_flag', FeatureFlagRuntime::class)
+            ->args([service('feature_flag.feature_checker')->nullOnInvalid()])
+            ->tag('twig.runtime')
+
+        ->set('twig.extension.feature_flag', FeatureFlagExtension::class)
+            ->tag('twig.extension')
+    ;
+};

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/feature_flag.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/feature_flag.html.twig
@@ -1,0 +1,122 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block page_title 'Feature Flag' %}
+
+{% block toolbar %}
+    {% if 0 < collector.features|length %}
+        {% set icon %}
+            <img alt="Feature Flag" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABVElEQVRIie2UO0oEURBFzxM/YGroAgQNxETUwEzwiytQ8/GzAhfhEnQNYqaJ4IyCv1QjERQjB1HEQDkGU8qzmRkHNJwLTcOtqtNVr6sb2mrrX6X2qOvqsfpi63qJmjW1O2emDN4P7AHDQAW4BpaznEpcCRgHxsLfAR4z7xKYTyndFTu/VKvqtNqnXkR3VXW6zrQzETtTuwre+Y9J1I2AFeHWg2d1s5Gz2sxDPVHLGfxVfVLLjeBZ7XExL7wKQEd4g8AVsA8MAIvAB/DrA4AjYKiR15mZK8BbwA+A3hbg3003j9ZGelen1A51O86x8iu5VntUxyvnxnoAlzL4YdxnmsDnIqfUzPta0wv1I4Kbapf6EGs32wBeVU/VzoJ39rWmxQ9tFxgBboBbYDJjnlB76QmYAEapnf1WwTsHFlJK9/VG7lZXY2WfbV3PUVOy8Ktoq62/6xORLdg+h+zBmgAAAABJRU5ErkJggg==" />
+            <span class="sf-toolbar-value">{{ collector.features|length }}</span>
+        {% endset %}
+
+        {% set text %}
+            <div class="sf-toolbar-info-group">
+                {% for feature_name, data in collector.features|filter(d => d.is_enabled is not null) %}
+                    <div class="sf-toolbar-info-piece">
+                            <b>{{ loop.first ? 'Resolved features' : '' }}</b>
+                            <span class="sf-toolbar-status sf-toolbar-status-{{ data['is_enabled'] ? 'green' : 'red' }}">
+                                {{ feature_name }}
+                            </span>
+                            <br />
+                    </div>
+                {% endfor %}
+            </div>
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
+    {% endif %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label {{ collector.features|length is same as(0) ? 'disabled' }}">
+        <span class="icon"><img alt="Feature Flag" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABVElEQVRIie2UO0oEURBFzxM/YGroAgQNxETUwEzwiytQ8/GzAhfhEnQNYqaJ4IyCv1QjERQjB1HEQDkGU8qzmRkHNJwLTcOtqtNVr6sb2mrrX6X2qOvqsfpi63qJmjW1O2emDN4P7AHDQAW4BpaznEpcCRgHxsLfAR4z7xKYTyndFTu/VKvqtNqnXkR3VXW6zrQzETtTuwre+Y9J1I2AFeHWg2d1s5Gz2sxDPVHLGfxVfVLLjeBZ7XExL7wKQEd4g8AVsA8MAIvAB/DrA4AjYKiR15mZK8BbwA+A3hbg3003j9ZGelen1A51O86x8iu5VntUxyvnxnoAlzL4YdxnmsDnIqfUzPta0wv1I4Kbapf6EGs32wBeVU/VzoJ39rWmxQ9tFxgBboBbYDJjnlB76QmYAEapnf1WwTsHFlJK9/VG7lZXY2WfbV3PUVOy8Ktoq62/6xORLdg+h+zBmgAAAABJRU5ErkJggg==" /></span>
+        <strong>Feature Flag</strong>
+    </span>
+{% endblock %}
+
+{% block head %}
+    {{ parent() }}
+    <style>
+        tr.feature-check {
+            position: relative;
+        }
+        tr.feature-check > td:first-child:before {
+            border-radius: 0;
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+        }
+        tr.feature-check-enabled > td:first-child:before {
+            background: var(--green-500);
+        }
+        tr.feature-check-disabled > td:first-child:before {
+            background: var(--red-500);
+        }
+        tr.feature-check-unknown > td:first-child:before {
+            background: var(--gray-400);
+        }
+        .badge {
+            color: var(--white);
+            display: inline-block;
+            text-align: center;
+            min-width: 100px;
+        }
+        .badge.badge-enabled {
+            background-color: var(--green-500);
+        }
+        .badge.badge-disabled {
+            background-color: var(--red-500);
+        }
+        .badge.badge-unknown {
+            background-color: var(--gray-400);
+        }
+    </style>
+{% endblock %}
+
+{% block panel %}
+    <h2>Features</h2>
+    {% if collector.features|length > 0 %}
+        <table>
+            <thead>
+            <tr>
+                <th>Feature</th>
+                <th>Resolved value</th>
+                <th>Enabled</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for feature_name, data in collector.features %}
+                {% set result = data['is_enabled'] is not null ? (data['is_enabled'] ? 'enabled' : 'disabled') : 'unknown' %}
+                <tr class="feature-check feature-check-{{ result }}">
+                    <td>{{ feature_name }}</td>
+                    <td>
+                        {% if data['value'].value is not null %}
+                            {{ profiler_dump(data['value'], maxDepth=2) }}
+                        {% else %}
+                            <span class="text-muted">Not resolved</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if data['is_enabled'] is not null %}
+                            <span class="badge badge-{{ result }}">
+                                {{ result|capitalize }}
+                            </span>
+                        {% else %}
+                            <span class="badge badge-unknown">
+                                Not resolved
+                            </span>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="empty">
+            <p>No features checked</p>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/Symfony/Component/FeatureFlag/.gitattributes
+++ b/src/Symfony/Component/FeatureFlag/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/FeatureFlag/.gitignore
+++ b/src/Symfony/Component/FeatureFlag/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/FeatureFlag/Attribute/AsFeature.php
+++ b/src/Symfony/Component/FeatureFlag/Attribute/AsFeature.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag\Attribute;
+
+/**
+ * Service tag to autoconfigure feature flags.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class AsFeature
+{
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly ?string $method = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/FeatureFlag/CHANGELOG.md
+++ b/src/Symfony/Component/FeatureFlag/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.1
+---
+
+ * Add the component as experimental

--- a/src/Symfony/Component/FeatureFlag/DataCollector/FeatureCheckerDataCollector.php
+++ b/src/Symfony/Component/FeatureFlag/DataCollector/FeatureCheckerDataCollector.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag\DataCollector;
+
+use Symfony\Component\FeatureFlag\FeatureRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+
+final class FeatureCheckerDataCollector extends DataCollector implements LateDataCollectorInterface
+{
+    private array $isEnabledLogs = [];
+    private array $valueLogs = [];
+
+    public function __construct(
+        private readonly FeatureRegistry $featureRegistry,
+    )
+    {
+        $this->data = [
+            'features' => [],
+        ];
+    }
+
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    {
+    }
+
+    public function collectIsEnabled(string $featureName, bool $result): void
+    {
+        $this->isEnabledLogs[$featureName] = $result;
+    }
+
+    public function collectValue(string $featureName, mixed $value): void
+    {
+        $this->valueLogs[$featureName] = $value;
+    }
+
+    public function getName(): string
+    {
+        return 'feature_flag';
+    }
+
+    public function reset(): void
+    {
+        $this->data = [
+            'features' => [],
+        ];
+    }
+
+    public function lateCollect(): void
+    {
+        $this->data['features'] = [];
+        foreach ($this->featureRegistry->getNames() as $featureName) {
+            $this->data['features'][$featureName] = [
+                'is_enabled' => $this->isEnabledLogs[$featureName] ?? null,
+                'value' => $this->cloneVar($this->valueLogs[$featureName] ?? null),
+            ];
+        }
+    }
+
+    public function getFeatures(): array
+    {
+        return $this->data['features'];
+    }
+}

--- a/src/Symfony/Component/FeatureFlag/Debug/TraceableFeatureChecker.php
+++ b/src/Symfony/Component/FeatureFlag/Debug/TraceableFeatureChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag\Debug;
+
+use Symfony\Component\FeatureFlag\DataCollector\FeatureCheckerDataCollector;
+use Symfony\Component\FeatureFlag\FeatureCheckerInterface;
+
+final class TraceableFeatureChecker implements FeatureCheckerInterface
+{
+    public function __construct(
+        private readonly FeatureCheckerInterface $decorated,
+        private readonly FeatureCheckerDataCollector $dataCollector,
+    ) {
+    }
+
+    public function isEnabled(string $featureName, mixed $expectedValue = true): bool
+    {
+        $isEnabled = $this->decorated->isEnabled($featureName, $expectedValue);
+
+        $this->dataCollector->collectIsEnabled($featureName, $isEnabled);
+        $this->dataCollector->collectValue($featureName, $this->decorated->getValue($featureName));
+
+        return $isEnabled;
+    }
+
+    public function getValue(string $featureName): mixed
+    {
+        $value = $this->decorated->getValue($featureName);
+
+        $this->dataCollector->collectValue($featureName, $value);
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/FeatureFlag/FeatureChecker.php
+++ b/src/Symfony/Component/FeatureFlag/FeatureChecker.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag;
+
+final class FeatureChecker implements FeatureCheckerInterface
+{
+    private array $cache = [];
+
+    public function __construct(
+        private readonly FeatureRegistry $featureRegistry,
+        private readonly mixed $default,
+    ) {
+    }
+
+    public function isEnabled(string $featureName, mixed $expectedValue = true): bool
+    {
+        return $this->getValue($featureName) === $expectedValue;
+    }
+
+    public function getValue(string $featureName): mixed
+    {
+        try {
+            return $this->cache[$featureName] ??= $this->featureRegistry->get($featureName)();
+        } catch (FeatureNotFoundException) {
+            return $this->default;
+        }
+    }
+}

--- a/src/Symfony/Component/FeatureFlag/FeatureCheckerInterface.php
+++ b/src/Symfony/Component/FeatureFlag/FeatureCheckerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag;
+
+interface FeatureCheckerInterface
+{
+    public function isEnabled(string $featureName, mixed $expectedValue = true): bool;
+
+    public function getValue(string $featureName): mixed;
+}

--- a/src/Symfony/Component/FeatureFlag/FeatureNotFoundException.php
+++ b/src/Symfony/Component/FeatureFlag/FeatureNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag;
+
+class FeatureNotFoundException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/FeatureFlag/FeatureRegistry.php
+++ b/src/Symfony/Component/FeatureFlag/FeatureRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag;
+
+final class FeatureRegistry implements FeatureRegistryInterface
+{
+    /**
+     * @param array<string, (\Closure(): mixed)> $features
+     */
+    public function __construct(private readonly array $features) {}
+
+    public function get(string $featureName): callable
+    {
+        return $this->features[$featureName] ?? throw new FeatureNotFoundException(sprintf('Feature "%s" not found.', $featureName));
+    }
+
+    public function getNames(): array
+    {
+        return array_keys($this->features);
+    }
+}

--- a/src/Symfony/Component/FeatureFlag/FeatureRegistryInterface.php
+++ b/src/Symfony/Component/FeatureFlag/FeatureRegistryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\FeatureFlag;
+
+interface FeatureRegistryInterface
+{
+    public function get(string $featureName): callable;
+
+    /**
+     * @return array<string>
+     */
+    public function getNames(): array;
+}

--- a/src/Symfony/Component/FeatureFlag/LICENSE
+++ b/src/Symfony/Component/FeatureFlag/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/FeatureFlag/README.md
+++ b/src/Symfony/Component/FeatureFlag/README.md
@@ -1,0 +1,20 @@
+FeatureFlag Component
+======================
+
+The FeatureFlag component provides a service that checks if a feature is
+enabled. A feature is a callable which returns a value compared to the
+expected one to determine is the feature is enabled (mostly a boolean but not
+limited to).
+
+**This Component is experimental**.
+[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
+are not covered by Symfony's
+[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/FeatureFlag/composer.json
+++ b/src/Symfony/Component/FeatureFlag/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "symfony/feature-flag",
+    "type": "library",
+    "description": "Provide a feature flag mechanism.",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\FeatureFlag\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/FeatureFlag/phpunit.xml.dist
+++ b/src/Symfony/Component/FeatureFlag/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony FeatureFlag Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
# Simple FeatureFlags component

## Introduction

Co-authored with @Neirda24 who is at the origin of this component.

See initial pull request #51649.

## Proposal

The FeatureFlags component provides a service that checks if a feature is enabled. A feature is a callable which returns
a value compared to the expected one to determine is the feature is enabled (mostly a boolean but not limited to).

## The component

Declare features and the default result if a feature is not found:
```php
<?php

use Symfony\Component\FeatureFlags\FeatureChecker;
use Symfony\Component\FeatureFlags\FeatureRegistry;

$features = new FeatureRegistry([
    'weekend_feature' => fn() => date('N') >= 6,
    'feature_version' => fn() => random_int(1, 3),
];
$featureChecker = new FeatureChecker($features, false);
```

Check the feature's value:
```php
$featureChecker->isEnabled('weekend_feature'); // returns true on weekend
$featureChecker->isEnabled('not_a_feature'); // returns false
```

Check the feature's value on a specific value or simply retrieve it:
```php
$featureChecker->isEnabled('feature_version', 1); // returns true if random version is 1
$featureChecker->getValue('feature_version'); // returns a random version between 1 and 3
```

Once the feature's value is resolved, it is stored to make it immutable:
```php
$featureChecker->getValue('feature_version'); // returns a random version between 1 and 3
$featureChecker->getValue('feature_version'); // returns the previous value
```

## The bundle

### Feature as a service

With a name
```php
#[AsFeature('beta_feature')] # the name could be optional and default to the FQCN
class MyFeature
{
    public function __construct(private readonly \Symfony\Component\HttpFoundation\RequestStack $requestStack)
    {
    }

    function __invoke(): bool
    {
        return $this->requestStack->getMainRequest()->request->getBoolean('use_beta'); 
    }
}
```

With a specific method
```php
#[AsFeature('beta_feature', method: 'compute')]
class MyFeature
{
    function compute(): bool { /* ... */ }
}
```

On a method
```php
class MyFeature
{
    #[AsFeature('beta_feature')] # the name could be optional and default to the FQCN + "::" + the method's name
    function compute(): bool { /* ... */ }
}
```

### Usage with Twig

```twig
{% if is_feature_enabled('my-feature') %}
    {# do stuff #}
{% endif %}
```

```twig
You're using version {{ get_feature_value('feature_version') }}.
```

### Usage with Router

Using yaml
```yaml
my_route:
    # ...
    condition: 'is_feature_enabled("weekend_feature")'
```
```yaml
my_route:
    # ...
    condition: 'get_feature_value("feature_version") == 1'
```

Using attribute
```php
#[Route(condition: 'is_feature_enabled("weekend_feature")')]
```
```php
#[Route(condition: 'get_feature_value("feature_version") == 1')]
```

## The profiler

![image](https://github.com/Jean-Beru/symfony/assets/6114779/16833f54-0ab9-4c38-817c-514c21e7e8f4)

![image](https://github.com/Jean-Beru/symfony/assets/6114779/7199ff52-e4a3-459c-a44e-956992474939)

## Going further (to discuss)

* [ ] Add tests
* [ ] Add documentation
* [ ] SaaS tool integration (Gitlab, DarkLaunchy, etc.) by adding a dedicated FeatureRegistry 
```php
class GitlabFeatureRegistry implements FeatureRegistryInterface
{ /* call Gitlab API to get the feature's value */ }
class ChainFeatureRegistry implements FeatureRegistryInterface
{ /* iterate over inner registries to get the feature's value */ }
```
* [ ] Declare feature in configuration using the ExpressionLanguage
```yaml
feature_flags:
    features:
        beta_feature: 'request.query.getBoolean("beta")'
```
* [ ] Add `{% if 'my-feature' is enabled %}` Twig tag
* [ ] Add a debug command
* [ ] Allow feature's value caching (ex: opening my feature to a percentage of my visitors will only require a single 
user get the same value)
* [ ] Propose pre-implemented features (see previous example)
