### PR TITLE
[FrameworkBundle] Remove console service definitions already declared by ConsoleBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -65,7 +65,6 @@ use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -288,10 +287,6 @@ class FrameworkExtension extends Extension
 
             if (!class_exists(BaseTranslationLintCommand::class)) {
                 $container->removeDefinition('console.command.translation_lint');
-            }
-
-            if (!class_exists(DotenvDebugCommand::class)) {
-                $container->removeDefinition('console.command.dotenv_debug');
             }
 
             if (!class_exists(RunCommandMessageHandler::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -40,20 +40,8 @@ use Symfony\Bundle\FrameworkBundle\Command\TranslationExtractCommand;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
-use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\BackedEnumValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\BuiltinTypeValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\DateTimeValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\DefaultValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\InputFileValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\MapInputValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\ServiceValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\UidValueResolver;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\VariadicValueResolver;
-use Symfony\Component\Console\EventListener\ErrorListener;
 use Symfony\Component\Console\EventListener\ValidateQuestionInputListener;
 use Symfony\Component\Console\Messenger\RunCommandMessageHandler;
-use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
 use Symfony\Component\ErrorHandler\Command\ErrorDumpCommand;
 use Symfony\Component\Form\Command\DebugCommand;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
@@ -76,13 +64,6 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
-        ->set('console.error_listener', ErrorListener::class)
-            ->args([
-                service('logger')->nullOnInvalid(),
-            ])
-            ->tag('kernel.event_subscriber')
-            ->tag('monolog.logger', ['channel' => 'console'])
-
         ->set('console.suggest_missing_package_subscriber', SuggestMissingPackageSubscriber::class)
             ->tag('kernel.event_subscriber')
 
@@ -164,13 +145,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 null,
                 service('debug.file_link_formatter')->nullOnInvalid(),
-            ])
-            ->tag('console.command')
-
-        ->set('console.command.dotenv_debug', DotenvDebugCommand::class)
-            ->args([
-                param('kernel.environment'),
-                param('kernel.project_dir'),
             ])
             ->tag('console.command')
 
@@ -428,51 +402,5 @@ return static function (ContainerConfigurator $container) {
                 service('console.messenger.application'),
             ])
             ->tag('messenger.message_handler', ['sign' => true])
-
-        ->set('console.argument_resolver', ArgumentResolver::class)
-            ->public()
-            ->args([
-                abstract_arg('argument value resolvers'),
-                abstract_arg('named argument value resolvers'),
-            ])
-
-        ->set('console.argument_resolver.backed_enum', BackedEnumValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => BackedEnumValueResolver::class])
-
-        ->set('console.argument_resolver.uid', UidValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => UidValueResolver::class])
-
-        ->set('console.argument_resolver.input_file', InputFileValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => InputFileValueResolver::class])
-
-        ->set('console.argument_resolver.builtin_type', BuiltinTypeValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => BuiltinTypeValueResolver::class])
-
-        ->set('console.argument_resolver.datetime', DateTimeValueResolver::class)
-            ->args([
-                service('clock')->nullOnInvalid(),
-            ])
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => DateTimeValueResolver::class])
-
-        ->set('console.argument_resolver.map_input', MapInputValueResolver::class)
-            ->args([
-                service('console.argument_resolver.builtin_type'),
-                service('console.argument_resolver.backed_enum'),
-                service('console.argument_resolver.datetime'),
-                service('validator')->nullOnInvalid(),
-            ])
-            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => MapInputValueResolver::class])
-
-        ->set('console.argument_resolver.service', ServiceValueResolver::class)
-            ->args([
-                abstract_arg('service locator, set in RegisterCommandArgumentLocatorsPass'),
-            ])
-            ->tag('console.argument_value_resolver', ['priority' => -50, 'name' => ServiceValueResolver::class])
-
-        ->set('console.argument_resolver.default', DefaultValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => -100, 'name' => DefaultValueResolver::class])
-
-        ->set('console.argument_resolver.variadic', VariadicValueResolver::class)
-            ->tag('console.argument_value_resolver', ['priority' => -150, 'name' => VariadicValueResolver::class])
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since the introduction of `ConsoleBundle` (via `#[RequiredBundle(ConsoleBundle::class)]` on `FrameworkBundle`), several services are declared twice: once in `Component/Console/Resources/config/console.php` and once in `FrameworkBundle/Resources/config/console.php`. These duplicates were pointed out by Nicolas.

Both bundles are always loaded together (`hasConsole()` guards the FrameworkBundle load, and `ConsoleBundle` exists iff the Console component is installed). The DI container silently overwrites the first definition with the identical second one.

This PR removes the redundant definitions from FrameworkBundle:
- `console.error_listener`
- `console.command.dotenv_debug`
- `console.argument_resolver` and all `console.argument_resolver.*` value resolvers
- The now-unnecessary `DotenvDebugCommand` class existence check in `FrameworkExtension`